### PR TITLE
Update network definition for the Keras 2.0 api

### DIFF
--- a/wide_resnet.py
+++ b/wide_resnet.py
@@ -4,8 +4,8 @@ import logging
 import sys
 import numpy as np
 from keras.models import Model
-from keras.layers import Input, Activation, merge, Dense, Flatten, Dropout
-from keras.layers.convolutional import Convolution2D, AveragePooling2D
+from keras.layers import Input, Activation, add, Dense, Flatten, Dropout
+from keras.layers.convolutional import Conv2D, AveragePooling2D
 from keras.layers.normalization import BatchNormalization
 from keras.regularizers import l2
 from keras import backend as K
@@ -36,9 +36,9 @@ class WideResNet:
     def _wide_basic(self, n_input_plane, n_output_plane, stride):
         def f(net):
             # format of conv_params:
-            #               [ [nb_col="kernel width", nb_row="kernel height",
-            #               subsample="(stride_vertical,stride_horizontal)",
-            #               border_mode="same" or "valid"] ]
+            #               [ [kernel_size=("kernel width", "kernel height"),
+            #               strides="(stride_vertical,stride_horizontal)",
+            #               padding="same" or "valid"] ]
             # B(3,3): orignal <<basic>> block
             conv_params = [[3, 3, stride, "same"],
                            [3, 3, (1, 1), "same"]]
@@ -55,39 +55,40 @@ class WideResNet:
                     else:
                         convs = BatchNormalization(axis=self._channel_axis)(net)
                         convs = Activation("relu")(convs)
-                    convs = Convolution2D(n_bottleneck_plane, nb_col=v[0], nb_row=v[1],
-                                          subsample=v[2],
-                                          border_mode=v[3],
-                                          init=self._weight_init,
-                                          W_regularizer=l2(self._weight_decay),
-                                          bias=self._use_bias)(convs)
+
+                    convs = Conv2D(n_bottleneck_plane, kernel_size=(v[0], v[1]),
+                                          strides=v[2],
+                                          padding=v[3],
+                                          kernel_initializer=self._weight_init,
+                                          kernel_regularizer=l2(self._weight_decay),
+                                          use_bias=self._use_bias)(convs)
                 else:
                     convs = BatchNormalization(axis=self._channel_axis)(convs)
                     convs = Activation("relu")(convs)
                     if self._dropout_probability > 0:
                         convs = Dropout(self._dropout_probability)(convs)
-                    convs = Convolution2D(n_bottleneck_plane, nb_col=v[0], nb_row=v[1],
-                                          subsample=v[2],
-                                          border_mode=v[3],
-                                          init=self._weight_init,
-                                          W_regularizer=l2(self._weight_decay),
-                                          bias=self._use_bias)(convs)
+                    convs = Conv2D(n_bottleneck_plane, kernel_size=(v[0], v[1]),
+                                          strides=v[2],
+                                          padding=v[3],
+                                          kernel_initializer=self._weight_init,
+                                          kernel_regularizer=l2(self._weight_decay),
+                                          use_bias=self._use_bias)(convs)
 
-            # Shortcut Conntection: identity function or 1x1 convolutional
+            # Shortcut Connection: identity function or 1x1 convolutional
             #  (depends on difference between input & output shape - this
             #   corresponds to whether we are using the first block in each
             #   group; see _layer() ).
             if n_input_plane != n_output_plane:
-                shortcut = Convolution2D(n_output_plane, nb_col=1, nb_row=1,
-                                         subsample=stride,
-                                         border_mode="same",
-                                         init=self._weight_init,
-                                         W_regularizer=l2(self._weight_decay),
-                                         bias=self._use_bias)(net)
+                shortcut = Conv2D(n_output_plane, kernel_size=(1, 1),
+                                         strides=stride,
+                                         padding="same",
+                                         kernel_initializer=self._weight_init,
+                                         kernel_regularizer=l2(self._weight_decay),
+                                         use_bias=self._use_bias)(net)
             else:
                 shortcut = net
 
-            return merge([convs, shortcut], mode="sum")
+            return add([convs, shortcut])
 
         return f
 
@@ -113,12 +114,12 @@ class WideResNet:
 
         n_stages = [16, 16 * self._k, 32 * self._k, 64 * self._k]
 
-        conv1 = Convolution2D(nb_filter=n_stages[0], nb_row=3, nb_col=3,
-                              subsample=(1, 1),
-                              border_mode="same",
-                              init=self._weight_init,
-                              W_regularizer=l2(self._weight_decay),
-                              bias=self._use_bias)(inputs)  # "One conv at the beginning (spatial size: 32x32)"
+        conv1 = Conv2D(filters=n_stages[0], kernel_size=(3, 3),
+                              strides=(1, 1),
+                              padding="same",
+                              kernel_initializer=self._weight_init,
+                              kernel_regularizer=l2(self._weight_decay),
+                              use_bias=self._use_bias)(inputs)  # "One conv at the beginning (spatial size: 32x32)"
 
         # Add wide residual blocks
         block_fn = self._wide_basic
@@ -129,14 +130,14 @@ class WideResNet:
         relu = Activation("relu")(batch_norm)
 
         # Classifier block
-        pool = AveragePooling2D(pool_size=(8, 8), strides=(1, 1), border_mode="same")(relu)
+        pool = AveragePooling2D(pool_size=(8, 8), strides=(1, 1), padding="same")(relu)
         flatten = Flatten()(pool)
-        predictions_g = Dense(output_dim=2, init=self._weight_init, bias=self._use_bias,
-                              W_regularizer=l2(self._weight_decay), activation="softmax")(flatten)
-        predictions_a = Dense(output_dim=101, init=self._weight_init, bias=self._use_bias,
-                              W_regularizer=l2(self._weight_decay), activation="softmax")(flatten)
+        predictions_g = Dense(units=2, kernel_initializer=self._weight_init, use_bias=self._use_bias,
+                              kernel_regularizer=l2(self._weight_decay), activation="softmax")(flatten)
+        predictions_a = Dense(units=101, kernel_initializer=self._weight_init, use_bias=self._use_bias,
+                              kernel_regularizer=l2(self._weight_decay), activation="softmax")(flatten)
 
-        model = Model(input=inputs, output=[predictions_g, predictions_a])
+        model = Model(inputs=inputs, outputs=[predictions_g, predictions_a])
 
         return model
 


### PR DESCRIPTION
Hi, this updates `wide_resnet.py` so it works without warnings on Keras 2.0. Otherwise it is unchanged.

Feel free to reject this PR if you still prefer to use Keras 1.0. I just wanted to share these changes in case this was also helpful to you.